### PR TITLE
feat: enhance Firecrawl API integration with optional API URL

### DIFF
--- a/credentials/FirecrawlApi.credentials.ts
+++ b/credentials/FirecrawlApi.credentials.ts
@@ -15,5 +15,13 @@ export class FirecrawlApi implements ICredentialType {
 			description:
 				'The API key for authenticating with Firecrawl API. Get your API key from firecrawl.dev',
 		},
+		{
+			displayName: 'API URL',
+			name: 'apiUrl',
+			type: 'string',
+			default: 'https://api.firecrawl.dev',
+			required: false,
+			description: 'Custom API URL for Firecrawl (default firecrawl.dev)',
+		},
 	];
 }

--- a/nodes/Firecrawl/resources/crawler/crawler.methods.ts
+++ b/nodes/Firecrawl/resources/crawler/crawler.methods.ts
@@ -7,11 +7,14 @@ export const crawlerMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/crawler/crawler.methods.ts
+++ b/nodes/Firecrawl/resources/crawler/crawler.methods.ts
@@ -14,7 +14,7 @@ export const crawlerMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/extract/extract.methods.ts
+++ b/nodes/Firecrawl/resources/extract/extract.methods.ts
@@ -91,7 +91,7 @@ export const extractMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/extract/extract.methods.ts
+++ b/nodes/Firecrawl/resources/extract/extract.methods.ts
@@ -84,11 +84,14 @@ export const extractMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/map/map.methods.ts
+++ b/nodes/Firecrawl/resources/map/map.methods.ts
@@ -7,11 +7,14 @@ export const mapMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/map/map.methods.ts
+++ b/nodes/Firecrawl/resources/map/map.methods.ts
@@ -14,7 +14,7 @@ export const mapMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/scrape/scrape.methods.ts
+++ b/nodes/Firecrawl/resources/scrape/scrape.methods.ts
@@ -14,7 +14,7 @@ export const scrapeMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/scrape/scrape.methods.ts
+++ b/nodes/Firecrawl/resources/scrape/scrape.methods.ts
@@ -7,11 +7,14 @@ export const scrapeMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {


### PR DESCRIPTION
### Summary
Adds an optional **API URL** to the Firecrawl credentials so that custom or self-hosted endpoints can be used. Default behaviour remains unchanged.

### Key Changes
* **credentials/FirecrawlApi.credentials.ts**
  * new optional `apiUrl` field (`string`, default `https://api.firecrawl.dev`)
* **crawler / extract / map / scrape methods**
  * retrieve `{ apiKey, apiUrl }`
  * `baseUrl = apiUrl || 'https://api.firecrawl.dev'`
  * instantiate `FirecrawlApp({ apiKey, apiUrl: baseUrl })`
* Net diff: **32 additions / 12 deletions**

### Compatibility
* Fully backward-compatible; no config or DB migration required.

### Test Plan
1. Run node with no `apiUrl` → should call default endpoint.
2. Set a custom URL in credentials → requests should target that URL.
3. Provide an invalid URL → verify existing error handling.

### Review Notes
* Check description text for the new credential field.
* Optional: update README examples to include `apiUrl`.