### PR TITLE
fix(crawler): pass scrapeOptions to crawlUrl and upgrade deps

### DIFF
--- a/credentials/FirecrawlApi.credentials.ts
+++ b/credentials/FirecrawlApi.credentials.ts
@@ -15,5 +15,13 @@ export class FirecrawlApi implements ICredentialType {
 			description:
 				'The API key for authenticating with Firecrawl API. Get your API key from firecrawl.dev',
 		},
+		{
+			displayName: 'API URL',
+			name: 'apiUrl',
+			type: 'string',
+			default: 'https://api.firecrawl.dev',
+			required: false,
+			description: 'Custom API URL for Firecrawl (default firecrawl.dev)',
+		},
 	];
 }

--- a/nodes/Firecrawl/resources/crawler/crawler.methods.ts
+++ b/nodes/Firecrawl/resources/crawler/crawler.methods.ts
@@ -7,11 +7,14 @@ export const crawlerMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/crawler/crawler.methods.ts
+++ b/nodes/Firecrawl/resources/crawler/crawler.methods.ts
@@ -14,7 +14,7 @@ export const crawlerMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/crawler/crawler.methods.ts
+++ b/nodes/Firecrawl/resources/crawler/crawler.methods.ts
@@ -23,14 +23,13 @@ export const crawlerMethods = {
 				const url = this.getNodeParameter('url', i) as string;
 				const limit = this.getNodeParameter('limit', i) as number;
 
-				// Prepare crawl parameters
-				const crawlParams: any = {
-					limit,
-					formats: ['markdown'], // Only use markdown format
-				};
-
 				// Crawl URL
-				const crawlResponse = await firecrawl.crawlUrl(url, crawlParams);
+				const crawlResponse = await firecrawl.crawlUrl(url, {
+					limit,
+					scrapeOptions: {
+						formats: ['markdown'],
+					}
+				});
 
 				// Add result to return data
 				returnData.push({

--- a/nodes/Firecrawl/resources/extract/extract.methods.ts
+++ b/nodes/Firecrawl/resources/extract/extract.methods.ts
@@ -91,7 +91,7 @@ export const extractMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/extract/extract.methods.ts
+++ b/nodes/Firecrawl/resources/extract/extract.methods.ts
@@ -84,11 +84,14 @@ export const extractMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/map/map.methods.ts
+++ b/nodes/Firecrawl/resources/map/map.methods.ts
@@ -7,11 +7,14 @@ export const mapMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/map/map.methods.ts
+++ b/nodes/Firecrawl/resources/map/map.methods.ts
@@ -14,7 +14,7 @@ export const mapMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/scrape/scrape.methods.ts
+++ b/nodes/Firecrawl/resources/scrape/scrape.methods.ts
@@ -14,7 +14,7 @@ export const scrapeMethods = {
 
 		// Initialize Firecrawl app
 		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
-    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
+		const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/nodes/Firecrawl/resources/scrape/scrape.methods.ts
+++ b/nodes/Firecrawl/resources/scrape/scrape.methods.ts
@@ -7,11 +7,14 @@ export const scrapeMethods = {
 		const returnData: INodeExecutionData[] = [];
 
 		// Get credentials
-		const credentials = await this.getCredentials('firecrawlApi');
-		const apiKey = credentials.apiKey as string;
+		const { apiKey, apiUrl } = await this.getCredentials('firecrawlApi') as {
+			apiKey: string;
+			apiUrl?: string
+		};
 
 		// Initialize Firecrawl app
-		const firecrawl = new FirecrawlApp({ apiKey });
+		const baseUrl = apiUrl || 'https://api.firecrawl.dev';
+    	const firecrawl = new FirecrawlApp({ apiKey, apiUrl: baseUrl });
 
 		// Process each item
 		for (let i = 0; i < items.length; i++) {

--- a/package.json
+++ b/package.json
@@ -45,18 +45,18 @@
 		]
 	},
 	"devDependencies": {
-		"@typescript-eslint/parser": "^7.15.0",
-		"eslint": "^8.56.0",
+		"@typescript-eslint/parser": "8.32.1",
+		"eslint": "9.27.0",
 		"eslint-plugin-n8n-nodes-base": "^1.16.1",
-		"gulp": "^4.0.2",
-		"n8n-workflow": "*",
+		"gulp": "5.0.0",
+		"n8n-workflow": "1.92.0",
 		"prettier": "^3.3.2",
 		"typescript": "^5.5.3"
 	},
 	"peerDependencies": {
-		"n8n-workflow": "*"
+		"n8n-workflow": "1.92.0"
 	},
 	"dependencies": {
-		"@mendable/firecrawl-js": "^1.18.2"
+		"@mendable/firecrawl-js": "^1.25.0"
 	}
 }


### PR DESCRIPTION
### Summary
Simplifies crawler parameter handling and updates dependencies, fixing a crawl failure.

### Changes
* **nodes/Firecrawl/resources/crawler/crawler.methods.ts**  
  * Remove interim `crawlParams`; call `crawlUrl` with  
    `{ limit, scrapeOptions: { formats: ['markdown'] } }`.
* **package.json**  
  * Upgrade dev/peer deps: `@typescript-eslint/parser`, `eslint`, `gulp`, `n8n-workflow`.  
  * Upgrade runtime dep: `@mendable/firecrawl-js` → `^1.25.0`.